### PR TITLE
Update url for cinc17 examples

### DIFF
--- a/ecg/examples/cinc17/setup.sh
+++ b/ecg/examples/cinc17/setup.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-url=https://www.physionet.org/challenge/2017/
+#url=https://www.physionet.org/challenge/2017/
+url=https://archive.physionet.org/challenge/2017/
 
 mkdir data && cd data
 


### PR DESCRIPTION
The dataset of examples/cinc17 is now 404 not found.

So I update the url to archieved one.